### PR TITLE
Dev transparent btn

### DIFF
--- a/src/apollo/types.ts
+++ b/src/apollo/types.ts
@@ -341,6 +341,7 @@ export type Query = {
   featuredOrganizations: Array<Organization>;
   organization: Organization;
   currentUser: User;
+  searchUser: Array<User>;
   user: User;
   tags: Array<Tag>;
   tag: Tag;
@@ -352,6 +353,10 @@ export type QueryEventArgs = {
 
 export type QueryOrganizationArgs = {
   id: Scalars["Int"];
+};
+
+export type QuerySearchUserArgs = {
+  keyword: Scalars["String"];
 };
 
 export type QueryUserArgs = {
@@ -505,7 +510,7 @@ export type UpdateUserInput = {
   gender?: Maybe<Gender>;
   academicYear?: Maybe<Scalars["Int"]>;
   organizations?: Maybe<Array<UserOrganizationInput>>;
-  events?: Maybe<Array<EventInput>>;
+  history?: Maybe<Array<EventInput>>;
   profilePicture?: Maybe<Scalars["Upload"]>;
 };
 
@@ -528,7 +533,7 @@ export type User = {
   gender: Gender;
   academicYear?: Maybe<Scalars["Int"]>;
   organizations: Array<UserOrganization>;
-  events: Array<Event>;
+  history: Array<Event>;
   interests: Array<Tag>;
 };
 
@@ -580,7 +585,7 @@ export type UserInput = {
   gender: Gender;
   academicYear?: Maybe<Scalars["Int"]>;
   organizations: Array<UserOrganizationInput>;
-  events: Array<EventInput>;
+  history: Array<EventInput>;
   interests: Array<TagInput>;
 };
 
@@ -631,7 +636,7 @@ export type GetCurrentUserQuery = { __typename?: "Query" } & {
     | "didSetup"
     | "gender"
   > & {
-      events: Array<
+      history: Array<
         { __typename?: "Event" } & Pick<
           Event,
           "id" | "name" | "posterImageUrl" | "posterImageHash"
@@ -700,9 +705,12 @@ export type GetEventByIdQuery = { __typename?: "Query" } & {
     | "coverImageUrl"
     | "coverImageHash"
   > & {
-      location?: Maybe<{ __typename?: "Location" } & Pick<Location, "name">>;
+      location?: Maybe<
+        { __typename?: "Location" } & Pick<Location, "id" | "name">
+      >;
       organization: { __typename?: "Organization" } & Pick<
         Organization,
+        | "id"
         | "name"
         | "abbreviation"
         | "description"
@@ -744,7 +752,9 @@ export type GetQuestionsByEventIdQuery = { __typename?: "Query" } & {
           "id" | "start" | "finish"
         >
       >;
-      location?: Maybe<{ __typename?: "Location" } & Pick<Location, "name">>;
+      location?: Maybe<
+        { __typename?: "Location" } & Pick<Location, "id" | "name">
+      >;
       questionGroups: Array<
         { __typename?: "QuestionGroup" } & Pick<QuestionGroup, "eventId"> & {
             questions: Array<
@@ -788,7 +798,9 @@ export type GetFeaturedEventsQuery = { __typename?: "Query" } & {
             "id" | "start" | "finish"
           >
         >;
-        location?: Maybe<{ __typename?: "Location" } & Pick<Location, "name">>;
+        location?: Maybe<
+          { __typename?: "Location" } & Pick<Location, "id" | "name">
+        >;
         tags: Array<{ __typename?: "Tag" } & Pick<Tag, "id" | "name">>;
       }
   >;
@@ -850,19 +862,7 @@ export type GetEventUserCheckinQuery = { __typename?: "Query" } & {
         >
       >;
       attendance?: Maybe<
-        { __typename?: "UserEvent" } & Pick<
-          UserEvent,
-          "id" | "userId" | "ticket"
-        > & {
-            user: { __typename?: "User" } & Pick<
-              User,
-              | "firstName"
-              | "lastName"
-              | "email"
-              | "phoneNumber"
-              | "profilePictureUrl"
-            >;
-          }
+        { __typename?: "UserEvent" } & Pick<UserEvent, "id" | "ticket">
       >;
     };
 };

--- a/src/commons/UI/BaseTransparentButton.vue
+++ b/src/commons/UI/BaseTransparentButton.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    class="bg-transparent hover:text-gray-5 focus:text-primary focus:outline-none"
+    class="flex items-center justify-center bg-transparent hover:text-gray-5 focus:text-primary focus:outline-none"
   >
     <slot></slot>
   </button>

--- a/src/commons/components/org-navbar/org-navbar-team/OrgNavbarTeam.vue
+++ b/src/commons/components/org-navbar/org-navbar-team/OrgNavbarTeam.vue
@@ -4,20 +4,18 @@
     class="py-4 px-1 flex flex-col items-center h-screen bg-blue-11 sticky left-0 top-0 bottom-0 z-40"
     :class="{ 'w-8': !isExpand, 'w-30': isExpand }"
   >
-    <span
+    <base-transparent-button
       v-if="!isExpand"
       @click="expandNavbar"
-      class="flex items-center justify-center cursor-pointer w-full h-5 -mt-1"
-      ><base-icon :width="24" :height="24" class="text-white"
-        ><MenuIcon /></base-icon
-    ></span>
-    <span
+      class="w-full h-5 -mt-1 text-white"
+      ><base-icon :width="24" :height="24"><MenuIcon /></base-icon
+    ></base-transparent-button>
+    <base-transparent-button
       v-else
       @click="collapseNavbar"
-      class="absolute right-0 top-1 flex justify-center items-center w-5 h-5 cursor-pointer"
-      ><base-icon :width="24" :height="24" class="text-white"
-        ><XIcon /></base-icon
-    ></span>
+      class="absolute right-0 top-1 w-5 h-5 text-white"
+      ><base-icon :width="24" :height="24"><XIcon /></base-icon
+    ></base-transparent-button>
     <section
       class="items-center"
       :class="{ 'mt-3': !isExpand, 'mt-7': isExpand }"
@@ -48,6 +46,7 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 import OrgNavbarTeamSelection from "../org-navbar-team-selection/OrgNavbarTeamSelection.vue";
+import BaseTransparentButton from "@/commons/UI/BaseTransparentButton.vue";
 import MenuIcon from "@/assets/Menu.vue";
 import XIcon from "@/assets/X.vue";
 import PlusIcon from "@/assets/Plus.vue";
@@ -57,6 +56,7 @@ export default defineComponent({
   name: "OrgNavbarTeam",
   components: {
     OrgNavbarTeamSelection,
+    BaseTransparentButton,
     MenuIcon,
     XIcon,
     PlusIcon

--- a/src/commons/components/page-navbar/PageNavbar.vue
+++ b/src/commons/components/page-navbar/PageNavbar.vue
@@ -39,12 +39,14 @@
         <div class="text-lg font-heading max-w-20 truncate mr-1.5">
           {{ nameShown }}
         </div>
-        <base-icon v-show="!isDropDownShown" :height="14" :width="14">
-          <ChevronDownIcon />
-        </base-icon>
-        <base-icon v-show="isDropDownShown" :height="14" :width="14">
-          <ChevronUpIcon />
-        </base-icon>
+        <base-transparent-button
+          ><base-icon v-show="!isDropDownShown" :height="14" :width="14">
+            <ChevronDownIcon /> </base-icon
+        ></base-transparent-button>
+        <base-transparent-button
+          ><base-icon v-show="isDropDownShown" :height="14" :width="14">
+            <ChevronUpIcon /> </base-icon
+        ></base-transparent-button>
       </div>
       <NavbarDropDownOptions
         v-show="isDropDownShown"
@@ -61,6 +63,7 @@ import { defineComponent } from "vue";
 import BaseButton from "@/commons/UI/BaseButton.vue";
 import BaseSearch from "@/commons/UI/BaseSearch.vue";
 import UserProfile from "@/commons/UI/user-profile/UserProfile.vue";
+import BaseTransparentButton from "@/commons/UI/BaseTransparentButton.vue";
 import OnePassLogo from "@/assets/OnePassLogoColor.vue";
 import ChevronDownIcon from "@/assets/ChevronDown.vue";
 import ChevronUpIcon from "@/assets/ChevronUp.vue";
@@ -74,6 +77,7 @@ export default defineComponent({
     BaseButton,
     BaseSearch,
     UserProfile,
+    BaseTransparentButton,
     OnePassLogo,
     ChevronDownIcon,
     ChevronUpIcon,

--- a/src/commons/components/page-skeleton/PageSkeleton.vue
+++ b/src/commons/components/page-skeleton/PageSkeleton.vue
@@ -19,9 +19,3 @@ export default defineComponent({
   }
 });
 </script>
-
-<style scoped>
-.content-min-height {
-  min-height: calc(100vh - 224px);
-}
-</style>

--- a/src/commons/components/page-skeleton/organization/PageSkeletonOrg.vue
+++ b/src/commons/components/page-skeleton/organization/PageSkeletonOrg.vue
@@ -2,7 +2,9 @@
   <section class="flex flex-col w-full h-full">
     <!-- Need to change to org navbar -->
     <PageNavbar />
-    <router-view></router-view>
+    <div class="content-min-height bg-gray-1">
+      <router-view></router-view>
+    </div>
     <PageFooter />
   </section>
 </template>

--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,10 @@
     max-width: 570px;
   }
 
+  .content-min-height {
+    min-height: calc(100vh - 224px);
+  }
+
   .content-max-width-s {
     max-width: 794px;
   }

--- a/src/modules/authentication/api.ts
+++ b/src/modules/authentication/api.ts
@@ -22,7 +22,7 @@ export const useCurrentUser = (enabled: Ref<boolean>) =>
           profilePictureUrl
           didSetup
           gender
-          events {
+          history {
             id
             name
             durations {

--- a/src/modules/wallet/wallet/Wallet.vue
+++ b/src/modules/wallet/wallet/Wallet.vue
@@ -150,7 +150,7 @@ export default defineComponent({
     } = useWallet();
 
     const findApprovedEvents = computed(() =>
-      props.profile.events?.filter(
+      props.profile.history?.filter(
         value => value.attendance?.status === UserEventStatus.Approved
       )
     );

--- a/src/modules/wallet/wallet/Wallet.vue
+++ b/src/modules/wallet/wallet/Wallet.vue
@@ -20,13 +20,9 @@
           <h1 class="font-heading text-4xl mr-3">
             {{ profile.firstName }} {{ profile.lastName }}
           </h1>
-          <base-icon
-            @click="editInfo"
-            width="20px"
-            height="20px"
-            class="cursor-pointer"
-            ><EditIcon
-          /></base-icon>
+          <base-transparent-button @click="editInfo"
+            ><base-icon width="20px" height="20px"><EditIcon /></base-icon
+          ></base-transparent-button>
         </div>
         <p class="text-gray-6 mb-1">{{ profile.email }}</p>
         <div class="flex items-center">
@@ -121,8 +117,9 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, PropType } from "vue";
+import { computed, defineComponent } from "vue";
 import LazyImage from "@/commons/UI/lazy-image/LazyImage.vue";
+import BaseTransparentButton from "@/commons/UI/BaseTransparentButton.vue";
 import EditIcon from "@/assets/Edit.vue";
 import TicketComponent from "@/modules/wallet/ticket/Ticket.vue";
 import useWallet from "./useWallet";
@@ -132,6 +129,7 @@ export default defineComponent({
   name: "Wallet",
   components: {
     LazyImage,
+    BaseTransparentButton,
     EditIcon,
     TicketComponent
   },


### PR DESCRIPTION
1. Change clickable icon to be in base transparent button instead
a. Pen icon in Wallet 
![image](https://user-images.githubusercontent.com/46432146/115153111-7ef20800-a09e-11eb-81ad-e74181029fba.png)
b. Chevron icon in navbar
![image](https://user-images.githubusercontent.com/46432146/115153120-903b1480-a09e-11eb-9ec8-812ccb6816de.png)
c. Hamburger icon in org side navbar
![image](https://user-images.githubusercontent.com/46432146/115153130-9af5a980-a09e-11eb-813f-65bc5d06374b.png)


2. Fix api regarding User by changing getting 'events' to 'history'
3. Make page skeleton for org also have min content height