### PR TITLE
feat: Add register due date to info banner

### DIFF
--- a/src/commons/components/info-banner/InfoBanner.vue
+++ b/src/commons/components/info-banner/InfoBanner.vue
@@ -48,13 +48,23 @@
         class="object-cover w-full h-full"
       />
     </div>
-    <base-button
-      :disabled="attendance"
-      @click="register"
+    <section
       v-if="canRegister"
-      class="absolute bottom-3 right-3 w-15 h-4.5"
-      >{{ registerMessage }}</base-button
+      class="absolute bottom-4.5 right-3 flex flex-col bg-gray-2 rounded-lg"
     >
+      <base-button
+        :disabled="attendance"
+        @click="register"
+        class="w-15 h-4.5 mb-0.25"
+        >{{ registerMessage }}</base-button
+      >
+      <p
+        v-if="hasRegisterDueDate"
+        class="w-full  text-center font-semibold text-primary"
+      >
+        Due: {{ registerDueDate }}
+      </p>
+    </section>
   </div>
 </template>
 
@@ -100,12 +110,24 @@ export default defineComponent({
   },
   setup(props) {
     const { eventBanner, isSignIn, attendance } = toRefs(props);
-    const { date, time, register, location, registerMessage } = useInfoBanner(
-      isSignIn,
-      attendance,
-      eventBanner
-    );
-    return { date, time, register, location, registerMessage };
+    const {
+      date,
+      time,
+      register,
+      location,
+      registerMessage,
+      registerDueDate,
+      hasRegisterDueDate
+    } = useInfoBanner(isSignIn, attendance, eventBanner);
+    return {
+      date,
+      time,
+      register,
+      location,
+      registerMessage,
+      registerDueDate,
+      hasRegisterDueDate
+    };
   }
 });
 </script>

--- a/src/commons/components/info-banner/types.ts
+++ b/src/commons/components/info-banner/types.ts
@@ -11,6 +11,7 @@ export interface EventBanner {
   posterImageHash: string;
   id: number;
   attendance: AttendanceBanner;
+  registrationDueDate: string;
 }
 
 export interface AttendanceBanner {

--- a/src/commons/components/info-banner/useInfoBanner.ts
+++ b/src/commons/components/info-banner/useInfoBanner.ts
@@ -4,6 +4,7 @@ import { login } from "@/commons/utils/auth";
 import { EventDuration } from "@/apollo/types";
 import { EventBanner } from "./types";
 import { useRouter } from "vue-router";
+import { format } from "date-fns";
 
 const useInfoBanner = (
   isSignIn: Ref<boolean>,
@@ -19,6 +20,16 @@ const useInfoBanner = (
     getMainTimetable(event?.value?.durations as EventDuration[])
   );
 
+  const hasRegisterDueDate = computed(() => {
+    return !!event?.value?.registrationDueDate;
+  });
+
+  const registerDueDate = computed(() => {
+    if (!hasRegisterDueDate.value) return "";
+    const date = new Date(event?.value?.registrationDueDate as string);
+    return format(date, "d MMM");
+  });
+
   const location = computed(() => event?.value?.location?.name || "-");
   const registerMessage = computed(() =>
     attendance.value ? "Registered" : "Register"
@@ -31,7 +42,15 @@ const useInfoBanner = (
       router.push(`/event-register/${event?.value?.id}`);
     }
   };
-  return { date, time, location, register, registerMessage };
+  return {
+    date,
+    time,
+    location,
+    register,
+    registerMessage,
+    registerDueDate,
+    hasRegisterDueDate
+  };
 };
 
 export default useInfoBanner;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/46432146/116813483-321e2f00-ab7e-11eb-87dc-29dc4b5fff7e.png)

Currently cannot show because api has no event that has registerDueDate